### PR TITLE
Fixed 404 Page Not Rendering

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200


### PR DESCRIPTION
- Fixed the issue when a user renders to non-existing page, the 404 or Error page was not shown